### PR TITLE
remove Serve from the Conn interface

### DIFF
--- a/muxer.go
+++ b/muxer.go
@@ -19,10 +19,6 @@ type Stream interface {
 	SetWriteDeadline(time.Time) error
 }
 
-// StreamHandler is a function that handles streams
-// (usually those opened by the remote side)
-type StreamHandler func(Stream)
-
 // NoOpHandler do nothing. close streams as soon as they are opened.
 var NoOpHandler = func(s Stream) { s.Close() }
 
@@ -39,10 +35,6 @@ type Conn interface {
 
 	// AcceptStream accepts a stream opened by the other side.
 	AcceptStream() (Stream, error)
-
-	// Serve starts a loop, accepting incoming requests and calling
-	// `StreamHandler with them. (Use _instead of_ accept. not both.)
-	Serve(StreamHandler)
 }
 
 // Transport constructs go-stream-muxer compatible connections.


### PR DESCRIPTION
For some stream muxers it might be desirable to wrap `OpenStream` and `AcceptStream`. This wrapping doesn't work when `Serve` is implemented on the Conn.

This will be needed when we merge the QUIC PRs (see https://github.com/libp2p/go-libp2p-transport/pull/20).

UPDATE: as @Stebalien suggested in a [comment below](https://github.com/libp2p/go-stream-muxer/pull/16#issuecomment-323501082), this should be merged before merging the QUIC PRs.