### PR TITLE
Document Reset versus Close

### DIFF
--- a/muxer.go
+++ b/muxer.go
@@ -24,8 +24,8 @@ type Stream interface {
 	SetWriteDeadline(time.Time) error
 }
 
-// NoOpHandler do nothing. close streams as soon as they are opened.
-var NoOpHandler = func(s Stream) { s.Close() }
+// NoOpHandler do nothing. Resets streams as soon as they are opened.
+var NoOpHandler = func(s Stream) { s.Reset() }
 
 // Conn is a stream-multiplexing connection to a remote peer.
 type Conn interface {

--- a/muxer.go
+++ b/muxer.go
@@ -6,12 +6,17 @@ import (
 	"time"
 )
 
-// Stream is a bidirectional io pipe within a connection
+// Stream is a bidirectional io pipe within a connection.
 type Stream interface {
 	io.Reader
 	io.Writer
+
+	// Close closes the stream for writing. Reading will still work (that
+	// is, the remote side can still write).
 	io.Closer
 
+	// Reset closes both ends of the stream. Use this to tell the remote
+	// side to hang up and go away.
 	Reset() error
 
 	SetDeadline(time.Time) error


### PR DESCRIPTION
Also, make the NoOpHandler reset streams instead of closing them.

fixes #13