### PR TITLE
add go mod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,25 @@ language: go
 go:
   - 1.9.x
 
-install:
-  - make deps
+install: true
 
-script:
-  - bash <(curl -s https://raw.githubusercontent.com/ipfs/ci-helpers/master/travis-ci/run-standard-tests.sh)
+jobs:
+  include:
+    - stage: "build and test"
+      name: "gx"
+      script:
+        - make deps
+        - bash <(curl -s https://raw.githubusercontent.com/ipfs/ci-helpers/master/travis-ci/run-standard-tests.sh)
+
+    - name: "go mod"
+      script:
+        - export GO111MODULE=on
+        - make mod_deps
+        - bash <(curl -s https://raw.githubusercontent.com/ipfs/ci-helpers/master/travis-ci/run-standard-tests.sh)
 
 cache:
     directories:
+        - $GOPATH/pkg/mod
         - $GOPATH/src/gx
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: false
 language: go
 
 go:
-  - 1.9.x
+  - 1.11.x
 
 install: true
 

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,5 @@ deps: gx
 publish:
 	gx-go rewrite --undo
 
+mod_deps:
+	env GO111MODULE=on go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/libp2p/go-stream-muxer/v3

--- a/test/ttest.go
+++ b/test/ttest.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 	"time"
 
-	smux "github.com/libp2p/go-stream-muxer"
+	smux "github.com/libp2p/go-stream-muxer/v3"
 )
 
 var randomness []byte


### PR DESCRIPTION
Note: branch v3 contains pre-go modules master for any changes that need to be made.

This PR creates valid go modules v4. It also updates the CI to use go modules.

Once merged, master needs to be tagged v4.0.0.